### PR TITLE
Add support for negative indices

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var arrify = require('arrify');
 var numSort = require('num-sort');
+var arrayUniq = require('array-uniq');
 
 module.exports = function (str, i, opts) {
 	opts = opts || {};
@@ -8,7 +9,11 @@ module.exports = function (str, i, opts) {
 	var ret = [];
 	var lastIndex = 0;
 
-	arrify(i).sort(numSort.asc).forEach(function (el) {
+	arrayUniq(arrify(i).map(function (el) {
+		var val = el < 0 ? ((str.length - 1) - (el * -1)) : el;
+		
+		return val < 0 ? (val * -1) : val;
+	}).sort(numSort.asc)).forEach(function (el) {
 		el++;
 		ret.push(str.slice(lastIndex, opts.remove ? el - 1 : el));
 		lastIndex = el;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "indices"
   ],
   "dependencies": {
+    "array-uniq": "^1.0.2",
     "arrify": "^1.0.0",
     "num-sort": "^1.0.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,9 @@ var splitAt = require('split-at');
 splitAt('unicorn', 2);
 //=> ['uni', 'corn']
 
+splitAt('unicorn', -2);
+//=> ['unico', 'rn']
+
 splitAt('unicorn&rainbow', [6, 7]);
 //=> ['unicorn', '&', 'rainbow']
 
@@ -40,7 +43,7 @@ String to be split.
 
 Type: `number`, `array` of `number`
 
-One or more indices.
+One or more indices. A negative index is a 1-based position from the end of the string. For example, -1 is the index of the last place in the string. Duplicate indices are removed from the `index` array. A negative index and positive index that refer to the same position in the string are treated as duplicates.
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -5,22 +5,39 @@ var splitAt = require('./');
 
 test('splitAt()', function (t) {
 	assert.deepEqual(splitAt('unicorn', 2), ['uni', 'corn']);
+	assert.deepEqual(splitAt('unicorn', -2), ['unico', 'rn']);
 
 	assert.deepEqual(
 		splitAt('unicorn & rainbows', [6, 13, 2, 9]),
 		['uni', 'corn', ' & ', 'rain', 'bows']
 	);
 
+	assert.deepEqual(
+		splitAt('unicorn & rainbows', [-6, -13, -2, -9]),
+		['unico', 'rn &', ' ra', 'inbo', 'ws']
+	);
+
 	assert.deepEqual(splitAt('unicorn', 5), ['unicor', 'n']);
 	assert.deepEqual(splitAt('unicorn', 6), ['unicorn']);
-	assert.deepEqual(splitAt('unicorn', 100), ['unicorn']);
 
+	assert.deepEqual(splitAt('unicorn', -1), ['unicor', 'n']);
+
+	assert.deepEqual(splitAt('unicorn', 100), ['unicorn']);
+	assert.deepEqual(splitAt('unicorn', -100), ['unicorn']);
+
+	assert.deepEqual(splitAt('unicorn', [-4, 2]), [ 'uni', 'corn' ]);
+	
 	t.end();
 });
 
 test('remove option', function (t) {
 	assert.deepEqual(
 		splitAt('unicorn&rainbow', 7, {remove: true}),
+		['unicorn', 'rainbow']
+	);
+
+	assert.deepEqual(
+		splitAt('unicorn&rainbow', -7, {remove: true}),
 		['unicorn', 'rainbow']
 	);
 


### PR DESCRIPTION
Fixes #1.

This PR adds support for negative indices. This works by converting negative indices to their positive equivalents. The [array-uniq](https://www.npmjs.com/package/array-uniq) module has been added as a dependency and is being used to remove duplicate indices from the `index` array. 
